### PR TITLE
Clean up json functions interface

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,8 +1,7 @@
 Progress map
 
-* Add in shallow copy and depp copy variants.
-* Reconsider whether some functions should have *l/*v variants.
-* Give structs better names in the public interface
+* Write tests for the jsonCreate, jsonRead, jsonUpdate families.
+* Give structs better names in the public interface.
 
 CORE FUNCTIONALITY WORKING
 

--- a/json.c
+++ b/json.c
@@ -314,6 +314,16 @@ JsonNode *jsonReadndv(JsonNode *root, struct path **keys) {
   return jsonReadnd(jsonReadnsv(root, keys));
 }
 
+JsonNode *jsonCreatetsv(void *src, char type, JsonNode *root, struct path **keys) {
+  return jsonCreatensv(jsonCreatets(src, type), root, keys);
+}
+
+JsonNode *jsonCreatetdv(void *src, char type, JsonNode *root, struct path **keys) {
+  return jsonCreatensv(jsonCreatetd(src, type), root, keys);
+}
+
+JsonNode *jsonCreatetdv(void *src, char type, JsonNode *root, struct path **keys);
+
 int jsonReadts(void *dest, char type, JsonNode *root){
 	if (dest == NULL || root == NULL || root->type != type) {
     return -1;
@@ -420,8 +430,12 @@ JsonNode *jsonCreatendl(JsonNode *node, JsonNode *root, ...) {
   return new;
 }
 
+//JsonNode *jsonCreatensv(JsonNode *node, JsonNode *root, struct path **keys){
+//	return cmemcpy(node, jsonReadnsv(root, keys), sizeof(JsonNode));
+//}
+
 JsonNode *jsonCreatensv(JsonNode *node, JsonNode *root, struct path **keys){
-	return cmemcpy(node, jsonReadnsv(root, keys), sizeof(JsonNode));
+	return cmemcpy(node, jsonCreatendv(&((JsonNode) {.contents.a = NULL, .type = JSON_OBJECT, .next = NULL}), root, keys), sizeof(JsonNode));
 }
 
 JsonNode *jsonCreatendv(JsonNode *node, JsonNode *root, struct path **keys) {
@@ -570,6 +584,24 @@ int jsonUpdatetd(void *src, char type, JsonNode *root) {
 
 int jsonUpdatetdv(void *src, char type, JsonNode *root, struct path **keys) {
   return jsonReadtd(src, type, jsonReadnsv(root, keys));
+}
+
+JsonNode *jsonUpdatets(void *src, char type, JsonNode *root){
+  JsonNode *ret = NULL, *new = NULL;
+  new = jsonCreatets(src, type);
+  ret = cmemcpy(root, new, sizeof(JsonNode));
+  if(ret == NULL){
+    jsonDelete(new);
+  }
+  return ret;
+}
+
+JsonNode *jsonUpdatensv(JsonNode *src, JsonNode *root, struct path **keys){
+  return cmemcpy(jsonReadnsv(root, keys), src, sizeof(JsonNode));
+}
+
+JsonNode *jsonUpdatetsv(void *src, char type, JsonNode *root, struct path **keys){
+  return cmemcpy(jsonReadnsv(root, keys), jsonCreatets(src, type), sizeof(JsonNode));
 }
 
 int jsonReadtd(void *dest, char type, JsonNode *root) {

--- a/json.h
+++ b/json.h
@@ -56,14 +56,15 @@ int jsonLibEnd();
 JsonNode *jsonCreate();
 JsonNode *jsonCreatets(void *src, char type);
 JsonNode *jsonCreatetd(void *src, char type);
-#define jsonCreatensl(root, args...) cmemcpy(node, jsonReadnsl(root, ##args), sizeof(JsonNode))
-JsonNode *jsonCreatendl(JsonNode *node, JsonNode *root, ...);
+#define jsonCreatensl(root, args...) cmemcpy(node, jsonCreatndl(&((JsonNode) {.contents.a = NULL, .type = JSON_ARRAY, .flags = 0, .prev = NULL, .next = NULL}), root, ##args), sizeof(JsonNode))
 JsonNode *jsonCreatensv(JsonNode *node, JsonNode *root, struct path **keys);
+JsonNode *jsonCreatendl(JsonNode *node, JsonNode *root, ...);
 JsonNode *jsonCreatendv(JsonNode *node, JsonNode *root, struct path **keys);
-//JsonNode *jsonCreatetsl(void *src, char type, JsonNode *root, ...);
-//JsonNode *jsonCreatetdl(void *src, char type, JsonNode *root, ...);
-//JsonNode *jsonCreatetsv(void *src, char type, JsonNode *root, struct path **keys);
-//JsonNode *jsonCreatetdv(void *src, char type, JsonNode *root, struct path **keys);
+// both Createt* functions can leak memory
+#define jsonCreatetsl(src, type, root, args...) jsonCreatensl(jsonCreatets(src, type), root, ...)
+#define jsonCreatetdl(src, type, root, args...) jsonCreatensl(jsonCopy(src, type), root, ...)
+JsonNode *jsonCreatetsv(void *src, char type, JsonNode *root, struct path **keys);
+JsonNode *jsonCreatetdv(void *src, char type, JsonNode *root, struct path **keys);
 
 // read
 JsonNode *jsonReadnd(JsonNode *elem);
@@ -82,21 +83,21 @@ int jsonReadtd(void *dest, char type, JsonNode *root);
   jsonReadtd(dest, type, jsonReadnsl(root, ##args))
 int jsonReadtdv(void *dest, char type, JsonNode *root, struct path **keys);
 
+// bad interface for update method methods ts/tsv return JsonNode* while td/tdv return int
 // update
+int jsonUpdatetd(void *src, char type, JsonNode *root);
 JsonNode *jsonUpdatend(JsonNode *src, JsonNode *root);
 #define jsonUpdatendl(src, root, args...) jsonUpdatend(src, jsonReadnsl(root, ##args))
 JsonNode *jsonUpdatendv(JsonNode *src, JsonNode *root, struct path **keys);
-int jsonUpdatetd(void *src, char type, JsonNode *root);
 #define jsonUpdatetdl(src, type, root, args...)                                     \
   jsonUpdatetd(src, type, jsonReadnsl(root, ##args))
 int jsonUpdatetdv(void *src, char type, JsonNode *root, struct path **keys);
-//JsonNode *jsonUpdatetd(JsonNode *src, JsonNode *root);
-//#define jsonUpdatetdl(src, root, args...) jsonUpdatetd(src, jsonReadnsl(root, ##args))
-//JsonNode *jsonUpdatetdv(JsonNode *src, JsonNode *root, struct path **keys);
-//int jsonUpdatetd(void *src, char type, JsonNode *root);
-//#define jsonUpdatetdl(src, type, root, args...)                                     \
-//  jsonUpdatetd(src, type, jsonReadnsl(root, ##args))
-//int jsonUpdatetdv(void *src, char type, JsonNode *root, struct path **keys);
+JsonNode *jsonUpdatets(void *src, char type, JsonNode *root);
+#define jsonUpdatensl(src, root, args...) jsonUpdatens(src, jsonReadnsl(root, ##args))
+JsonNode *jsonUpdatensv(JsonNode *src, JsonNode *root, struct path **keys);
+#define jsonUpdatetsl(src, type, root, args...)                                     \
+  jsonUpdatets(src, type, jsonReadnsl(root, ##args))
+JsonNode *jsonUpdatetsv(void *src, char type, JsonNode *root, struct path **keys);
 
 // delete
 JsonNode *jsonDelete(JsonNode *elem);
@@ -149,4 +150,9 @@ void array_tests();
 void object_tests();
 void copy_tests();
 void interface_tests();
+
+void jsonCreate_tests();
+void jsonRead_tests();
+void jsonUpdate_tests();
+
 int main();


### PR DESCRIPTION
- **Reading arrays partially working**
- **Make FILE* an attribute of queue, json_open func**
- **Fix dangling pointers and update queue.h**
- **New baseline for gitignore**
- **We have arrays working**
- **Opening a json file returns the root node**
- **Use constant to define max_str_size**
- **Hashmaps are about halfway there**
- **Start on copy function**
- **Delete and grow operations working for hashmaps**
- **Organize tests**
- **Missed one**
- **Searching kind of working**
- **Better tests**
- **We can now deep copy arrays**
- **Copying arrays and objects actually working now**
- **Cleaning up method names for what library exposes**
- **Progress on the interface and static analysis**
- **Minor adjustments**
- **Output to string from internal represenation**
- **Revise dev container and remove strcpy/strncpy**
- **Add jsonCreatel**
- **Update methods are working**
- **Establish what I want for the API**
- **Progress on interface functions**
- **Break out data structures to separate files**
- **Clean up json functions interface**
