### PR TITLE
Use struct to manage paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-Wall -Wextra
+CFLAGS=-Wall -Wextra --std=c23
 DEBUG=-g3 -ggdb
 OPTIMIZE=-O3
 
@@ -23,23 +23,29 @@ release:
 
 
 ## build for development
-json: json.o queue.o hash.o array.o pool.o
-	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} json.o queue.o hash.o array.o pool.o -o json
+json: json.o jsonpath.o queue.o hash.o array.o pool.o cstring.o
+	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} json.o jsonpath.o queue.o hash.o array.o pool.o cstring.o -o json
 
-json.o: json.c
+json.o: json.c json.h ds.h
 	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} json.c -c -o json.o
 
-queue.o: queue.c
+jsonpath.o: jsonpath.c jsonpath.h ds.h
+	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} jsonpath.c -c -o jsonpath.o
+
+queue.o: queue.c queue.h ds.h
 	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} queue.c -c -o queue.o
 
-hash.o: hash.c
+hash.o: hash.c hash.h ds.h
 	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} hash.c -c -o hash.o
 
-array.o: array.c
+array.o: array.c array.h ds.h
 	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} array.c -c -o array.o
 
-pool.o: pool.c
+pool.o: pool.c pool.h ds.h
 	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} pool.c -c -o pool.o
+
+cstring.o: cstring.c cstring.h
+	${CC} ${CFLAGS} ${DEBUG} ${START_SMALL} ${TEST_BUILD} cstring.c -c -o cstring.o
 
 clean:
 	rm -f json tags *.ast *.pch *.plist *.o externalDefMap.txt gmon.out

--- a/TODO
+++ b/TODO
@@ -1,26 +1,14 @@
 Progress map
 
-Immediate
-* Refactor path struct as path_component, create actual path struct that holds a linked list of path components and functions as a kind of stack. Path struct would have push, pop, and clear functions.
-```
-typedef struct path {
-    PathComponent *head;
-    PathComponent *tail;
-    size_t members;
-} Path;
-```
-* Refactor functions related to deep copying a read as copying
-* Removes tests related to shallow copy
-* Use type aliased to char for flags
-* Use type aliased to char for type that a node holds
-* Implement jsonCheckType and jsonRead${TYPE} functions
-
 Core functionality
+* Split into public and private header
+* Remove deprecated (unused functions, argv style function calls).
 * Handle memory leaks for jsonCreate family
 * Give structs better names in the public interface.
+* Create public and private header files.
 
 Nice to have:
-* Make sure JSON dictionaries are sorted in the same order as input.
+* Make sure JSON dictionaries are sorted in the same order as input. (can use the existing prev and next pointers).
 * Use wchar_t for strings to properly handle 2 byte escapes (like \xabcd).
 * Use prev and next to connect together active nodes in a dictionary (saving deallocation time).
 

--- a/cstring.c
+++ b/cstring.c
@@ -1,0 +1,34 @@
+#include "cstring.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _CUSTOM_CSTRING_FUNCTIONS
+#define _CUSTOM_CSTRING_FUNCTIONS 1
+char *cstrncpy(char *dest, char *src, size_t m) {
+    size_t n = 0;
+
+    if (m == 0 || dest == NULL || src == NULL) {
+        return NULL;
+    }
+
+    // + 1 for trailing '\x00'
+    n = strlen(src) + 1;
+
+    if (n < m) {
+        m = n;
+    }
+    memcpy(dest, src, m);
+    dest[m - 1] = '\x00';
+    return dest;
+}
+
+void *cmemcpy(void *dest, const void *src, size_t count) {
+    if(dest == NULL || src == NULL || count == 0) {
+        return NULL;
+    }
+
+    return memcpy(dest, src, count);
+}
+#endif

--- a/cstring.h
+++ b/cstring.h
@@ -1,29 +1,4 @@
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
-char *cstrncpy(char *dest, char *src, size_t m) {
-  size_t n = 0;
-
-  if (m == 0 || dest == NULL || src == NULL) {
-    return NULL;
-  }
-
-  // + 1 for trailing '\x00'
-  n = strlen(src) + 1;
-
-  if (n < m) {
-    m = n;
-  }
-  memcpy(dest, src, m);
-  dest[m - 1] = '\x00';
-  return dest;
-}
-
-void *cmemcpy(void *dest, const void *src, size_t count){
-  if(dest == NULL || src == NULL || count == 0){
-    return NULL;
-  }
-
-  return memcpy(dest, src, count);
-}
+char *cstrncpy(char *dest, char *src, size_t m);
+void *cmemcpy(void *dest, const void *src, size_t count);

--- a/ds.h
+++ b/ds.h
@@ -132,7 +132,6 @@ struct json_path_partial {
     union path_holds path;
     jsonType type;
     struct json_path_partial *prev;
-    struct json_path_partial *next;
 };
 
 typedef struct json_path {

--- a/json.h
+++ b/json.h
@@ -13,12 +13,15 @@
 
 #include "ds.h"
 #include "cstring.h"
+#include "jsonpath.h"
 #include "queue.h"
 #include "hash.h"
 #include "array.h"
 #include "pool.h"
 
 #ifdef UNITY_BUILD
+#include "cstring.c"
+#include "jsonpath.c"
 #include "queue.c"
 #include "hash.c"
 #include "array.c"
@@ -45,13 +48,13 @@ int jsonLibEnd();
  */
 
 #define _KEY(k)                                                                \
-  &((struct json_path_partial) {.path.key = k, .type = JSON_OBJECT, .prev = NULL, .next = NULL})
+  &((struct json_path_partial) {.path.key = k, .type = JSON_OBJECT, .prev = NULL})
 
 /*
  * Expresses an offset as an index to be used when accessing an array's fields.
  */
 #define _INDEX(i)                                                              \
-  &((struct json_path_partial) {.path.index = i, .type = JSON_ARRAY, .prev = NULL, .next = NULL})
+  &((struct json_path_partial) {.path.index = i, .type = JSON_ARRAY, .prev = NULL})
 
 /*
  * Provides you with a new node.
@@ -71,6 +74,7 @@ JsonNode *jsonCreate(void *src, char type);
 #define jsonCreatel(src, type, root, args...) jsonUpdate(src, type, jsonCopyl(_jsonCreate(), root, ##args, NULL))
 //JsonNode *jsonCreatetdv(void *src, char type, JsonNode *root, struct json_path_partial **keys);
 JsonNode *jsonCreatev(void *src, char type, JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonCreates(void *src, char type, JsonNode *root, JsonPath *path);
 //JsonNode *jsonCreatets(void *src, char type);
 //#define jsonCreatetsl(src, type, root, args...) jsonCreatensl(jsonCreatets(src, type), root, ##args, NULL)
 //#define jsonCreatensl(root, args...) cmemcpy(jsonCreatndl(&((JsonNode) {.contents.a = NULL, .type = JSON_ARRAY, .flags = 0, .prev = NULL, .next = NULL}), node, root, ##args, NULL), sizeof(JsonNode))
@@ -83,6 +87,8 @@ JsonNode *_jsonReadl(JsonNode *root, ...);
 #define jsonReadl(root, args...) _jsonReadl((root), ##args, NULL)
 //JsonNode *jsonReadnsv(JsonNode *root, struct json_path_partial **keys);
 JsonNode *jsonReadv(JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonReads(JsonNode *root, JsonPath *path);
+JsonNode *jsonReads_recurse(JsonNode *root, struct json_path_partial *path);
 // ts* family expect a char**
 //JsonNode *jsonReadts(void *dest, char type, JsonNode *root);
 //#define jsonReadtsl(dest, type, root, args...) jsonReadts(dest, type, jsonReadnsl(root, ##args, NULL))
@@ -101,6 +107,7 @@ JsonNode *jsonUpdate(void *src, char type, JsonNode *root);
 #define jsonUpdatel(src, type, root, args...) jsonUpdate(src, type, jsonReadl(root, ##args, NULL))
 //JsonNode *jsonUpdatetdv(void *src, char type, JsonNode *root, struct json_path_partial **keys);
 JsonNode *jsonUpdatev(void *src, char type, JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonUpdates(void *src, char type, JsonNode *root, JsonPath *path);
 //JsonNode *jsonUpdatens(JsonNode *src, JsonNode *root);
 //JsonNode *jsonUpdatend(JsonNode *src, JsonNode *root);
 //#define jsonUpdatendl(src, root, args...) jsonUpdatend(src, jsonReadnsl(root, ##args))
@@ -119,33 +126,42 @@ JsonNode *_jsonCopyl(JsonNode *node, JsonNode *root, ...);
 #define jsonCopyl(node, root, args...) _jsonCopyl((node), (root), ##args, NULL)
 //JsonNode *jsonCreatendv(JsonNode *node, JsonNode *root, struct json_path_partial **keys);
 JsonNode *jsonCopyv(JsonNode *src, JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonCopys(JsonNode *src, JsonNode *root, JsonPath *path);
+JsonNode *jsonCopys_recurse(JsonNode *root, struct json_path_partial *path);
 
 // delete
 JsonNode *jsonDelete(JsonNode *elem);
 #define jsonDeletel(root, args...) jsonDelete(jsonReadl(root, ##args, NULL))
 JsonNode *jsonDeletev(JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonDeletes(JsonNode *root, JsonPath *path);
 
 // check type
 jsonType *jsonCheckType(JsonNode *root);
 #define jsonCheckTypel(root, args...) jsonCheckType(jsonReadl(root, ##args NULL))
 jsonType *jsonCheckTypev(JsonNode *root, struct json_path_partial **keys);
+jsonType *jsonCheckTypes(JsonNode *root, JsonPath *keys);
 
 // read{type}
 jsonLiteral *jsonReadLiteral(JsonNode *root);
 #define jsonReadLiterall(root, args...) jsonReadLiteral(jsonReadl(root, ##args, NULL))
 jsonLiteral *jsonReadLiteralv(JsonNode *root, struct json_path_partial **keys);
+jsonLiteral *jsonReadLiterals(JsonNode *root, JsonPath *path);
 double *jsonReadDouble(JsonNode *root);
 #define jsonReadDoublel(root, args...) jsonReadDouble(jsonReadl(root, ##args, NULL))
 double *jsonReadDoublev(JsonNode *root, struct json_path_partial **keys);
+double *jsonReadDoubles(JsonNode *root, JsonPath *path);
 char *jsonReadStr(JsonNode *root);
 #define jsonReadStrl(root, args...) jsonReadStr(jsonReadl(root, ##args, NULL))
 char *jsonReadStrv(JsonNode *root, struct json_path_partial **keys);
+char *jsonReadStrs(JsonNode *root, JsonPath *path);
 JsonNode *jsonReadArray(JsonNode *root);
 #define jsonReadArrayl(root, args...) jsonReadArray(jsonReadl(root, ##args, NULL))
 JsonNode *jsonReadArrayv(JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonReadArrays(JsonNode *root, JsonPath *path);
 JsonNode *jsonReadObject(JsonNode *root);
 #define jsonReadObjectl(root, args...) jsonReadObject(jsonReadl(root, ##args, NULL))
 JsonNode *jsonReadObjectv(JsonNode *root, struct json_path_partial **keys);
+JsonNode *jsonReadObjects(JsonNode *root, JsonPath *path);
 
 // output json structure and children as string
 int jsonOut(FILE *dest, char minify, JsonNode *elem);

--- a/jsonpath.c
+++ b/jsonpath.c
@@ -1,0 +1,138 @@
+#include "jsonpath.h"
+
+struct json_path_partial *copy_json_path_partial(struct json_path_partial *src) {
+    if(src == NULL) {
+        return NULL;
+    }
+
+    struct json_path_partial *dest = calloc(sizeof(struct json_path_partial), 1);
+
+    if(dest == NULL) {
+        return NULL;
+    }
+
+    switch(src->type) {
+    case(JSON_ARRAY):
+        dest->path.index = src->path.index;
+        dest->type = JSON_ARRAY;
+        break;
+
+    case(JSON_OBJECT):
+        if(src->path.key == NULL) {
+            free(dest);
+            return NULL;
+        }
+
+        size_t len = 1 + strlen(src->path.key);
+        char *ptr = calloc(sizeof(char), len);
+        if(ptr == NULL) {
+            free(dest);
+            return NULL;
+        }
+        cstrncpy(ptr, src->path.key, len);
+        dest->path.key = ptr;
+        dest->type = JSON_OBJECT;
+        break;
+
+    default:
+        free(dest);
+        return NULL;
+        break;
+    }
+
+    return dest;
+}
+
+int delete_json_path_partial(struct json_path_partial *path_partial) {
+    if(path_partial == NULL) {
+        return 1;
+    }
+
+    switch(path_partial->type) {
+    case(JSON_ARRAY):
+        break;
+    case(JSON_OBJECT):
+        //calling free when a pointer is NULL produces no issues
+        free(path_partial->path.key);
+        break;
+    default:
+        return 2;
+        break;
+    }
+
+    free(path_partial);
+
+    return 0;
+}
+
+JsonPath *_jsonPathPush(JsonPath *path, ...) {
+    va_list args;
+    va_start(args);
+
+    if(path == NULL) {
+        path = calloc(sizeof(JsonPath), 1);
+        if(path == NULL) {
+            return NULL;
+        }
+    }
+
+    struct json_path_partial *partial, *prev;
+
+    prev = path->tail;
+    partial = va_arg(args, struct json_path_partial*);
+    while(partial != NULL) {
+        partial = copy_json_path_partial(partial);
+        if(partial == NULL) {
+            jsonPathDelete(path);
+            return NULL;
+        }
+        if(path->head == NULL) {
+            path->head = partial;
+        }
+
+        partial->prev = prev;
+        path->tail = partial;
+        path->members += 1;
+
+        prev = partial;
+        partial = va_arg(args, struct json_path_partial*);
+    }
+
+    va_end(args);
+    return path;
+}
+
+int jsonPathPop(JsonPath *path) {
+    if(path == NULL) {
+        return 1;
+    }
+
+    if(path->tail != NULL) {
+        struct json_path_partial *prev_tail = path->tail;
+        delete_json_path_partial(prev_tail);
+
+        if(path->tail != path->head) {
+            path->tail = prev_tail->prev;
+        } else {
+            path->head = prev_tail->prev;
+            path->tail = prev_tail->prev;
+        }
+        path->members -= 1;
+    } else {
+        path->tail = NULL;
+        path->members = 0;
+    }
+
+    return 0;
+}
+
+int jsonPathDelete(JsonPath *path) {
+    if(path == NULL) {
+        return 1;
+    }
+
+    while(path->members != 0 && jsonPathPop(path) == 0);
+    free(path);
+
+    return 0;
+}

--- a/jsonpath.h
+++ b/jsonpath.h
@@ -1,0 +1,14 @@
+#include "ds.h"
+#include "cstring.h"
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+
+struct json_path_partial *copy_json_path_partial(struct json_path_partial *src);
+int delete_json_path_partial(struct json_path_partial *path_partial);
+
+JsonPath *_jsonPathPush(JsonPath *path, ...);
+#define jsonPathPush(path, args...) _jsonPathPush(path, ##args, NULL);
+int jsonPathPop(JsonPath *path);
+int jsonPathDelete(JsonPath *path);


### PR DESCRIPTION
- **Reading arrays partially working**
- **Make FILE* an attribute of queue, json_open func**
- **Fix dangling pointers and update queue.h**
- **New baseline for gitignore**
- **We have arrays working**
- **Opening a json file returns the root node**
- **Use constant to define max_str_size**
- **Hashmaps are about halfway there**
- **Start on copy function**
- **Delete and grow operations working for hashmaps**
- **Organize tests**
- **Missed one**
- **Searching kind of working**
- **Better tests**
- **We can now deep copy arrays**
- **Copying arrays and objects actually working now**
- **Cleaning up method names for what library exposes**
- **Progress on the interface and static analysis**
- **Minor adjustments**
- **Output to string from internal represenation**
- **Revise dev container and remove strcpy/strncpy**
- **Add jsonCreatel**
- **Update methods are working**
- **Establish what I want for the API**
- **Progress on interface functions**
- **Break out data structures to separate files**
- **Clean up json functions interface**
- **Some testing**
- **Major redesign to API**
- **Finish jsonCopy tests**
- **Finish jsonCreate tests and fix hashing logic**
- **Use struct to manage paths**
