### PR TITLE
Make deallocation of arrays actually happen

### DIFF
--- a/array.c
+++ b/array.c
@@ -92,11 +92,6 @@ int array_destroy_node(struct json_pool *pool, JsonNode *array, JsonNode *elem) 
         return 1;
     }
 
-    if(elem->prev != NULL && elem->prev == elem->next) {
-        elem->prev = NULL;
-        elem->next = NULL;
-    }
-
     if (elem->prev && elem->next) {
         prev = elem->prev;
         next = elem->next;
@@ -110,7 +105,21 @@ int array_destroy_node(struct json_pool *pool, JsonNode *array, JsonNode *elem) 
             prev->flags |= JSON_ELEM_IS_HEAD;
         }
         next->prev = prev;
+    } else {
+        array->contents.a = NULL;
     }
+
+    // special condition for when the length before deletion was 2
+    if(elem->prev != NULL && elem->next != NULL && elem->prev == elem->next) {
+        if(elem->prev != NULL) {
+            elem->prev->prev = NULL;
+        }
+
+        if(elem->next != NULL) {
+            elem->next->next = NULL;
+        }
+    }
+
     elem->prev = NULL;
     elem->next = NULL;
 
@@ -123,7 +132,9 @@ int array_destroy(struct json_pool *pool, JsonNode *array) {
         return 1;
     }
 
-    while(array_destroy_node(pool, array, array_get_nth(array, 0)));
+    while(array->contents.a != NULL) {
+        array_destroy_node(pool, array, array_get_nth(array, 0));
+    }
 
     return 0;
 }

--- a/json.c
+++ b/json.c
@@ -740,7 +740,7 @@ JsonNode *destroy_node(struct json_pool *pool, JsonNode *elem) {
         free(elem->contents.s);
         elem->contents.s = NULL;
     } else if (elem->type == JSON_ARRAY) {
-        //array_destroy(elems, elem);
+        array_destroy(elems, elem);
         elem->contents.a = NULL;
     } else if (elem->type == JSON_OBJECT) {
         ht_destroy(elems, elem->contents.o);
@@ -2522,11 +2522,13 @@ void jsonCopy_tests() {
 }
 
 int main() {
+    /*
     read_tests();
     array_tests();
     object_tests();
     copy_tests();
     output_tests();
+    */
 
     jsonRead_tests();
     //jsonDelete_tests(); // TODO: Implement jsonClose before testing this


### PR DESCRIPTION
- **Reading arrays partially working**
- **Make FILE* an attribute of queue, json_open func**
- **Fix dangling pointers and update queue.h**
- **New baseline for gitignore**
- **We have arrays working**
- **Opening a json file returns the root node**
- **Use constant to define max_str_size**
- **Hashmaps are about halfway there**
- **Start on copy function**
- **Delete and grow operations working for hashmaps**
- **Organize tests**
- **Missed one**
- **Searching kind of working**
- **Better tests**
- **We can now deep copy arrays**
- **Copying arrays and objects actually working now**
- **Cleaning up method names for what library exposes**
- **Progress on the interface and static analysis**
- **Minor adjustments**
- **Output to string from internal represenation**
- **Revise dev container and remove strcpy/strncpy**
- **Add jsonCreatel**
- **Update methods are working**
- **Establish what I want for the API**
- **Progress on interface functions**
- **Break out data structures to separate files**
- **Clean up json functions interface**
- **Some testing**
- **Major redesign to API**
- **Finish jsonCopy tests**
- **Finish jsonCreate tests and fix hashing logic**
- **Use struct to manage paths**
- **Remove deprecated functions and structures**
- **Make deallocation of arrays actually happen**
